### PR TITLE
Implement basic notification API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 # Elysia with Bun runtime
 
 ## Getting Started
-To get started with this template, simply paste this command into your terminal:
+To install dependencies run:
 ```bash
-bun create elysia ./elysia-example
+bun install
 ```
 
 ## Development
-To start the development server run:
+Start the development server:
 ```bash
 bun run dev
 ```
 
-Open http://localhost:3000/ with your browser to see the result.
+The API will be available at `http://localhost:3000`.
+
+### Endpoints
+- `POST /api/notify` - create a notification
+- `GET /api/notify` - list all notifications
+
+Example POST request:
+```bash
+curl -X POST http://localhost:3000/api/notify \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Собрание","description":"Команда в Zoom","datetime":"2025-07-12T17:00:00.000Z"}'
+```

--- a/README.md
+++ b/README.md
@@ -1,26 +1,60 @@
-# Elysia with Bun runtime
+# Notification API
+
+This project implements a very small REST API using [Elysia](https://elysiajs.com/) running on the [Bun](https://bun.sh) runtime. Data is stored in PostgreSQL and accessed via [Prisma](https://www.prisma.io/).
+
+## Prerequisites
+- **Bun** installed. If you do not have it, install it with:
+
+  ```bash
+  curl -fsSL https://bun.sh/install | bash
+  ```
+  Afterwards restart your shell so the `bun` command is available.
+- **Docker** (optional) if you want to run PostgreSQL via `docker-compose`.
 
 ## Getting Started
-To install dependencies run:
-```bash
-bun install
-```
+1. Install dependencies:
+   ```bash
+   bun install
+   ```
+2. (Optional) start PostgreSQL using Docker:
+   ```bash
+   docker-compose up -d
+   ```
+   This will start a database listening on `localhost:5432` with user `postgres` and password `password`.
+3. Create a `.env` file and configure the `DATABASE_URL` used by Prisma. Example:
+   ```env
+   DATABASE_URL="postgresql://postgres:password@localhost:5432/elysiadb"
+   ```
+4. Run the initial migration and generate the Prisma client:
+   ```bash
+   bunx prisma migrate dev --name init
+   bunx prisma generate
+   ```
 
 ## Development
-Start the development server:
+Start the development server with hot reload:
 ```bash
 bun run dev
 ```
+The API will be available at [http://localhost:3000](http://localhost:3000).
 
-The API will be available at `http://localhost:3000`.
+## API Endpoints
+- `POST /api/notify` – create a notification
+- `GET /api/notify` – list all notifications
 
-### Endpoints
-- `POST /api/notify` - create a notification
-- `GET /api/notify` - list all notifications
-
-Example POST request:
+### Example request
 ```bash
 curl -X POST http://localhost:3000/api/notify \
   -H "Content-Type: application/json" \
   -d '{"title":"Собрание","description":"Команда в Zoom","datetime":"2025-07-12T17:00:00.000Z"}'
 ```
+
+### Fetch all notifications
+```bash
+curl http://localhost:3000/api/notify
+```
+
+## Notes
+- The Prisma schema lives in `prisma/schema.prisma`.
+- If you change the schema, rerun `bunx prisma migrate dev` and `bunx prisma generate`.
+- Running Prisma commands may require internet access to download Prisma engines.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,3 +13,12 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model Notification {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  datetime    DateTime
+  createdAt   DateTime @default(now())
+}
+

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client'
+
+export const prisma = new PrismaClient()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,31 @@
-import { Elysia } from "elysia";
+import { Elysia } from 'elysia'
+import { prisma } from './db'
 
-const app = new Elysia().get("/", () => "Hello Elysia").listen(3000);
+const app = new Elysia()
 
-console.log(
-  `🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`
-);
+app.post('/api/notify', async ({ body }) => {
+  const { title, description, datetime } = body as Record<string, string>
+
+  if (!title || !description || !datetime) {
+    return { error: 'Все поля обязательны' }
+  }
+
+  const notification = await prisma.notification.create({
+    data: {
+      title,
+      description,
+      datetime: new Date(datetime)
+    }
+  })
+
+  return notification
+})
+
+app.get('/api/notify', async () => {
+  return await prisma.notification.findMany({
+    orderBy: { datetime: 'asc' }
+  })
+})
+
+app.listen(3000)
+console.log('🚀 Сервер работает на http://localhost:3000')


### PR DESCRIPTION
## Summary
- define Notification model in Prisma schema
- add Prisma client helper
- implement `/api/notify` create & list endpoints
- document how to run the API and example request

## Testing
- `bun x tsc --noEmit`
- `bun x prisma generate` *(fails: 403 Forbidden when downloading binaries)*

------
https://chatgpt.com/codex/tasks/task_e_6872b34e1d1483229554e690a489d71a